### PR TITLE
fixup regex for dokuwiki attachments

### DIFF
--- a/src/com/atlassian/uwc/converters/dokuwiki/DokuwikiAttachmentConverter.java
+++ b/src/com/atlassian/uwc/converters/dokuwiki/DokuwikiAttachmentConverter.java
@@ -18,7 +18,7 @@ public class DokuwikiAttachmentConverter extends HierarchyImageConverter {
 		page.setConvertedText(converted);
 	}
 
-	Pattern attachment = Pattern.compile("(?s)\\{\\{(.*?)\\}\\}");
+	Pattern attachment = Pattern.compile("(?s)\\{.\\{(.*?)\\}\\}");
 	Pattern parts = Pattern.compile("([^|?]+)(?:([?|])(.*))?");
 	Pattern type = Pattern.compile(".*?[.]([^.]+)$");
 	private String convertAttachments(Page page) {


### PR DESCRIPTION
Patch by Frédéric Beuserie from https://bitbucket.org/nul0op/universal-wiki-converter-dokuwiki/commits/5e63e0a9f3d6316edc3873054846c35a3a57d327

Solves issue #3 
