### PR TITLE
Add script to make Trac wiki attachments understandable by the UWC

### DIFF
--- a/trac_export_attachments.php
+++ b/trac_export_attachments.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Dumps Trac wiki attachments in a format understandable by the UWC.
+ *
+ * This script assumes Trac uses a Postgres server.
+ */
+
+$dbhost = 'localhost'; // Trac DB host
+$dbuser = 'trac'; // Trac DB username
+$dbpass = ''; // Trac DB password
+$dbname = 'trac'; // Trac DB name
+$rootdir = '/tmp/trac-attachments'; // Attachments will be dumped into this folder
+$tracenv = '/var/www/trac'; // Path to Trac environment
+
+
+$rs = pg_query("SELECT id,filename FROM attachment WHERE type='wiki'") or die ('query failed ' . pg_last_error());
+
+echo "#!/bin/bash\n";
+while($row = pg_fetch_array($rs)) {
+  $id = $row['id'];
+  $name = escapeshellarg($row['filename']);
+  $filedir = "$rootdir/$id";
+  $filepath = escapeshellarg($filedir . '/' . $row['filename']);
+  echo "echo mkdir -p $filedir\n";
+  echo "mkdir -p $filedir\n";
+  $command = "trac-admin $tracenv attachment export wiki:" . $id . " " . $name . " " . $filepath;
+  echo "echo $command\n";
+  echo $command . "\n";
+}
+pg_free_result($rs);
+pg_close($conn);
+


### PR DESCRIPTION
Hi and thanks for maintaining this tool - it saved us from many headaches.

It looks like the UWC does not understand the structure of Trac wiki attachments (we use Trac 1.0.6.post2). Here is a PHP script that exports Trac wiki attachments in a format the UWC seems to understand. The script is inspired by http://l33t.peopleperhour.com/2014/07/10/converting-a-trac-wiki-to-confluence/ - the latter did not seem to work so I had to modify it a bit.